### PR TITLE
Scope successful format reload to the original document

### DIFF
--- a/src/extensionController.ts
+++ b/src/extensionController.ts
@@ -348,6 +348,7 @@ export class ExtensionController implements vscode.Disposable, ExtensionApi {
     this.logger.info(`Running ${executablePath} ${args.join(" ")}.`);
 
     const processRunner = this.testHooks.processRunner ?? execFileProcessRunner;
+    const initialDocumentVersion = document.version;
     const processResult = await processRunner(executablePath, args, {
       cwd: workspaceFolderPath,
     });
@@ -376,8 +377,14 @@ export class ExtensionController implements vscode.Disposable, ExtensionApi {
       this.logger.warn(`stderr: ${processResult.stderr}`);
     }
 
-    await vscode.commands.executeCommand("workbench.action.files.revert");
-    this.logger.info(`Reloaded ${document.uri.fsPath} after a successful dfixxer update.`);
+    if (document.version !== initialDocumentVersion || document.isDirty) {
+      this.logger.warn(
+        `Skipped reloading ${document.uri.fsPath} because the document changed while dfixxer was running.`,
+      );
+      return;
+    }
+
+    await this.reloadDocument(document);
   }
 
   private async handleDidSaveTextDocument(document: vscode.TextDocument): Promise<void> {
@@ -496,6 +503,34 @@ export class ExtensionController implements vscode.Disposable, ExtensionApi {
       const errorMessage = error instanceof Error ? error.message : String(error);
       this.logger.warn(`Could not show ${document.uri.fsPath} for reload after formatting: ${errorMessage}`);
       return undefined;
+    }
+  }
+
+  private async reloadDocument(document: vscode.TextDocument): Promise<void> {
+    const previouslyActiveEditor = vscode.window.activeTextEditor;
+    const shouldRestorePreviousEditor =
+      previouslyActiveEditor && previouslyActiveEditor.document.uri.toString() !== document.uri.toString();
+
+    try {
+      await vscode.window.showTextDocument(document, { preserveFocus: false, preview: false });
+      await vscode.commands.executeCommand("workbench.action.files.revert");
+      this.logger.info(`Reloaded ${document.uri.fsPath} after a successful dfixxer update.`);
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`Could not reload ${document.uri.fsPath} after formatting: ${errorMessage}`);
+    } finally {
+      if (shouldRestorePreviousEditor) {
+        try {
+          await vscode.window.showTextDocument(previouslyActiveEditor.document, {
+            preserveFocus: false,
+            preview: false,
+            viewColumn: previouslyActiveEditor.viewColumn,
+          });
+        } catch (error: unknown) {
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          this.logger.warn(`Could not restore ${previouslyActiveEditor.document.uri.fsPath}: ${errorMessage}`);
+        }
+      }
     }
   }
 

--- a/src/test/suite/fixCurrentFile.test.ts
+++ b/src/test/suite/fixCurrentFile.test.ts
@@ -32,9 +32,26 @@ async function waitForText(document: vscode.TextDocument, expectedText: string):
   assert.equal(document.getText(), expectedText);
 }
 
+async function waitForCondition(
+  condition: () => boolean,
+  timeoutMs = 1000,
+): Promise<void> {
+  const startedAt = Date.now();
+  while (!condition()) {
+    if (Date.now() - startedAt > timeoutMs) {
+      break;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+
+  assert.equal(condition(), true);
+}
+
 suite("Fix Current File", () => {
   const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
   const pascalFilePath = workspaceRoot ? path.join(workspaceRoot, "fix-current-file-test.pas") : "";
+  const secondaryPascalFilePath = workspaceRoot ? path.join(workspaceRoot, "fix-current-file-secondary-test.pas") : "";
   const textFilePath = workspaceRoot ? path.join(workspaceRoot, "fix-current-file-test.txt") : "";
   const fakeExecutablePath = workspaceRoot ? path.join(workspaceRoot, "fake-dfixxer.exe") : "";
 
@@ -54,6 +71,7 @@ suite("Fix Current File", () => {
 
   teardown(async () => {
     await fs.rm(pascalFilePath, { force: true });
+    await fs.rm(secondaryPascalFilePath, { force: true });
     await fs.rm(textFilePath, { force: true });
   });
 
@@ -133,5 +151,92 @@ suite("Fix Current File", () => {
     const logText = api.getLogLines().join("\n");
     assert.match(logText, /stdout: stdout output/u);
     assert.match(logText, /stderr: stderr output/u);
+  });
+
+  test("keeps fresh in-editor edits when the formatted document changes again before completion", async () => {
+    const api = await getExtensionApi();
+    let releaseFormatter: (() => void) | undefined;
+
+    api.setTestHooks({
+      processRunner: (_executablePath, args) =>
+        new Promise((resolve, reject) => {
+          releaseFormatter = () => {
+            fs.writeFile(args[1] ?? "", "formatted text", "utf8")
+              .then(() => resolve({ exitCode: 0, stderr: "", stdout: "" }))
+              .catch(reject);
+          };
+        }),
+    });
+
+    await fs.writeFile(pascalFilePath, "original text", "utf8");
+    const editor = await openDocument(pascalFilePath);
+
+    const fixPromise = vscode.commands.executeCommand(commandIds.fixCurrentFile);
+    await waitForCondition(() => releaseFormatter !== undefined);
+
+    const activeEditor = await vscode.window.showTextDocument(editor.document);
+    const editApplied = await activeEditor.edit((editBuilder) => {
+      editBuilder.replace(
+        new vscode.Range(
+          activeEditor.document.positionAt(0),
+          activeEditor.document.positionAt(activeEditor.document.getText().length),
+        ),
+        "second draft",
+      );
+    });
+    assert.equal(editApplied, true);
+
+    assert.ok(releaseFormatter);
+    releaseFormatter();
+    await fixPromise;
+
+    assert.equal(editor.document.getText(), "second draft");
+    assert.equal(editor.document.isDirty, true);
+    assert.equal(await fs.readFile(pascalFilePath, "utf8"), "formatted text");
+  });
+
+  test("reloads only the formatted document when the active editor changed mid-run", async () => {
+    const api = await getExtensionApi();
+    let releaseFormatter: (() => void) | undefined;
+
+    api.setTestHooks({
+      processRunner: (_executablePath, args) =>
+        new Promise((resolve, reject) => {
+          releaseFormatter = () => {
+            fs.writeFile(args[1] ?? "", "formatted text", "utf8")
+              .then(() => resolve({ exitCode: 0, stderr: "", stdout: "" }))
+              .catch(reject);
+          };
+        }),
+    });
+
+    await fs.writeFile(pascalFilePath, "program Primary;", "utf8");
+    await fs.writeFile(secondaryPascalFilePath, "program Secondary;", "utf8");
+    const formattedEditor = await openDocument(pascalFilePath);
+    const secondaryDocument = await vscode.workspace.openTextDocument(secondaryPascalFilePath);
+    await vscode.window.showTextDocument(secondaryDocument);
+    await vscode.window.showTextDocument(formattedEditor.document);
+
+    const fixPromise = vscode.commands.executeCommand(commandIds.fixCurrentFile);
+    await waitForCondition(() => releaseFormatter !== undefined);
+
+    const secondaryEditor = await vscode.window.showTextDocument(secondaryDocument);
+    await secondaryEditor.edit((editBuilder) => {
+      editBuilder.replace(
+        new vscode.Range(
+          secondaryEditor.document.positionAt(0),
+          secondaryEditor.document.positionAt(secondaryEditor.document.getText().length),
+        ),
+        "program SecondaryDirty;",
+      );
+    });
+
+    assert.ok(releaseFormatter);
+    releaseFormatter();
+    await fixPromise;
+
+    await waitForText(formattedEditor.document, "formatted text");
+    assert.equal(secondaryEditor.document.getText(), "program SecondaryDirty;");
+    assert.equal(secondaryEditor.document.isDirty, true);
   });
 });


### PR DESCRIPTION
## Summary
Closes #2.

## Choices Made
- I kept the fix focused on the successful-format reload path and did not mix in the transient file-lock retry work from issue #5.
- I chose to guard reloads using the original document version plus dirty state instead of the active editor. That makes the decision local to the formatted document and avoids depending on whichever tab is focused when `dfixxer` finishes.
- I chose to restore the previously active editor after reloading the formatted document so the command does not leave the user in a different tab than the one they switched to while formatting was running.

## Problem
`runFix` captured the original Pascal document, but after awaiting the formatter it reloaded through `workbench.action.files.revert`, which applies to the active editor. If the user switched tabs or edited again before `dfixxer` finished, the command could revert the wrong editor or discard fresh edits in the formatted document.

## Fix
- Check whether the original document version changed while formatting was running.
- Skip the reload when that original document changed again or is dirty.
- Reload only the formatted document, then restore the previously active editor.
- Add regression tests for:
  - editing the formatted document again before completion
  - switching to another editor before completion

## Verification
- `npm test`
